### PR TITLE
Fix redirection, timeout session [PAR-25]

### DIFF
--- a/src/AuthContextProvider.tsx
+++ b/src/AuthContextProvider.tsx
@@ -50,8 +50,8 @@ function AuthContextProvider(props: any) {
     setAuthData(newCredential);
   };
 
-  function msToDays(days: number) {
-    return days / (24 * 60 * 60 * 1000);
+  function msToDays(ms: number) {
+    return ms / (24 * 60 * 60 * 1000);
   }
 
   const value: AuthInterface = {

--- a/src/FriendsPage.tsx
+++ b/src/FriendsPage.tsx
@@ -83,10 +83,9 @@ const FriendsPage: React.FC = () => {
   );
 
   return (
-    <PageLayout>
-      <h1>My Friends</h1>
-      sidebar=
-      {
+    <PageLayout
+      header={<h1>My Friends</h1>}
+      sidebar={
         <AutoTable
           data={nearbyPeople}
           title={<h3>Nearby People</h3>}
@@ -96,7 +95,7 @@ const FriendsPage: React.FC = () => {
           <button>Invite!</button>
         </AutoTable>
       }
-      >
+    >
       {!isLoaded ? (
         "Loading..."
       ) : error ? (

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -90,7 +90,7 @@ const LandingPage: React.FC = () => {
       .then(async (response) => {
         if (response.status === 200) {
           let json = await response.json();
-          auth.login({ authenticated: true, userId: json.userId });
+          auth.login({ authenticated: true, userId: json.userId }, json.maxAge);
         }
       })
       .catch((error) => {
@@ -102,23 +102,34 @@ const LandingPage: React.FC = () => {
     console.log(error);
   };
 
-  if (auth.credential.authenticated) {
-    return <Redirect to="/library" />;
-  }
   return (
-    <LandingLayout>
-      <Logo src="/images/logo-icon-black.png" alt="" />
-      <TitleText src="/images/logo-text-black.png" />
-      <SignIn>
-        <GoogleLogin
-          clientId="631703414652-navvamq2108qu88d9i7bo77gn2kqsi40.apps.googleusercontent.com"
-          buttonText="Sign in with Google"
-          onSuccess={loginSuccessHandler}
-          onFailure={loginFailureHandler}
-          cookiePolicy={"single_host_origin"}
-        />
-      </SignIn>
-    </LandingLayout>
+    <AuthContext.Consumer>
+      {(context) => {
+        if (context === undefined) {
+          console.error(
+            "The AuthContext Consumer must be used inside an AuthContextProvider"
+          );
+        }
+        if (context.credential.authenticated) {
+          return <Redirect to="/library" />;
+        }
+        return (
+          <LandingLayout>
+            <Logo src="/images/logo-icon-black.png" alt="" />
+            <TitleText src="/images/logo-text-black.png" />
+            <SignIn>
+              <GoogleLogin
+                clientId="631703414652-navvamq2108qu88d9i7bo77gn2kqsi40.apps.googleusercontent.com"
+                buttonText="Sign in with Google"
+                onSuccess={loginSuccessHandler}
+                onFailure={loginFailureHandler}
+                cookiePolicy={"single_host_origin"}
+              />
+            </SignIn>
+          </LandingLayout>
+        );
+      }}
+    </AuthContext.Consumer>
   );
 };
 

--- a/src/PageLayout.tsx
+++ b/src/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React from "react";
 import styled from "styled-components";
 import { AuthContext } from "./AuthContextProvider";
 import { Redirect } from "react-router-dom";
@@ -48,17 +48,26 @@ const PageLayout: React.FC<PageLayoutProps> = ({
   sidebar,
   children,
 }) => {
-  const auth = useContext(AuthContext);
-
-  if (!auth.credential.authenticated) {
-    return <Redirect to="/" />;
-  }
   return (
-    <Layout>
-      {header && <Header>{header}</Header>}
-      <Main>{children}</Main>
-      {sidebar && <Sidebar>{sidebar}</Sidebar>}
-    </Layout>
+    <AuthContext.Consumer>
+      {(context) => {
+        if (context === undefined) {
+          console.error(
+            "The AuthContext Consumer must be used inside an AuthContextProvider"
+          );
+        }
+        if (!context.credential.authenticated) {
+          return <Redirect to="/" />;
+        }
+        return (
+          <Layout>
+            {header && <Header>{header}</Header>}
+            <Main>{children}</Main>
+            {sidebar && <Sidebar>{sidebar}</Sidebar>}
+          </Layout>
+        );
+      }}
+    </AuthContext.Consumer>
   );
 };
 


### PR DESCRIPTION
This fixes the bug where refreshing the page or navigating via the address bar always took you to the / home page. This was because the authentication component wasn't loading before it's children, causing it to always redirect to the home page. Then, the homepage sent you back to the library page.

By returning <></> (nothing) until the auth is loaded from cookies, the child components no longer load ahead of the authentication provider.

This is meant to be merged in conjunction with backend PR: https://github.com/ParaLibrary/paralibrary-backend/pull/19/files which sends the cookie age on login. The front end accepts this number and sets our cookies to expire at the same time.

Also random fix to the Friends sidebar.