### PR TITLE
Table revamp [PAR-64]

### DIFF
--- a/src/AutoTable.tsx
+++ b/src/AutoTable.tsx
@@ -16,7 +16,6 @@ const Padding = styled.div`
 `;
 
 interface RowProps<T> {
-  id: string;
   template: React.ReactElement | React.ReactElement[];
   data: T;
   rowAs?:
@@ -29,7 +28,7 @@ interface RowProps<T> {
 }
 
 const TableRow = <T,>(props: RowProps<T>) => {
-  const { id, template, data, rowAs } = props;
+  const { template, data, rowAs } = props;
   const Row = rowAs || "tr";
   return (
     <Row>
@@ -48,7 +47,7 @@ const TableRow = <T,>(props: RowProps<T>) => {
           }
           return <Cell>{data[col]}</Cell>;
         }
-        return <Cell>{cloneElement(child, { id })}</Cell>;
+        return <Cell>{cloneElement(child, { data })}</Cell>;
       })}
     </Row>
   );
@@ -108,11 +107,10 @@ const AutoTable = <T extends { id: string }>(props: TableProps<T>) => {
             {data.map((row: T) => (
               <TableRow
                 key={row.id}
-                id={row.id}
                 data={row}
                 template={children}
                 rowAs={!!tableAs ? rowAs : undefined}
-              ></TableRow>
+              />
             ))}
           </Body>
         </Wrapper>

--- a/src/AutoTable.tsx
+++ b/src/AutoTable.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 interface TableColumnProps {
   col: string;
-  wrapper?: any;
+  component?: any;
 }
 
 export const TableColumn: React.FC<TableColumnProps> = ({ children }) => {
@@ -35,17 +35,20 @@ const TableRow = <T,>(props: RowProps<T>) => {
     <Row>
       {React.Children.map(template, (child: React.ReactElement) => {
         const childProps = child.props as TableColumnProps;
-        const Outer = !!rowAs ? React.Fragment : "td";
-        const Data = !!childProps.wrapper ? childProps.wrapper : React.Fragment;
+        const Cell = !!rowAs ? React.Fragment : "td";
+        const Wrapper = childProps.component;
         const col = (child.props as TableColumnProps).col as keyof T;
         if (col) {
-          return (
-            <Outer>
-              <Data data={data[col]}>{data[col]}</Data>
-            </Outer>
-          );
+          if (Wrapper) {
+            return (
+              <Cell>
+                <Wrapper data={data[col]} />
+              </Cell>
+            );
+          }
+          return <Cell>{data[col]}</Cell>;
         }
-        return <Data>{cloneElement(child, { id })}</Data>;
+        return <Cell>{cloneElement(child, { id })}</Cell>;
       })}
     </Row>
   );

--- a/src/AutoTable.tsx
+++ b/src/AutoTable.tsx
@@ -47,7 +47,7 @@ const TableRow = <T,>(props: RowProps<T>) => {
           }
           return <Cell>{data[col]}</Cell>;
         }
-        return <Cell>{cloneElement(child, { data })}</Cell>;
+        return <Cell>{cloneElement(child, { rowItem: data })}</Cell>;
       })}
     </Row>
   );

--- a/src/AutoTable.tsx
+++ b/src/AutoTable.tsx
@@ -1,6 +1,55 @@
-import React, { cloneElement, useMemo, ReactElement } from "react";
+import React, { cloneElement, useMemo, ReactElement, ReactNode } from "react";
 import { Table } from "react-bootstrap";
 import styled from "styled-components";
+
+interface TableColumnProps {
+  col: string;
+  wrapper?: any;
+}
+
+export const TableColumn: React.FC<TableColumnProps> = ({ children }) => {
+  return <th>{children}</th>;
+};
+
+const Padding = styled.div`
+  padding-bottom: 16px;
+`;
+
+interface RowProps<T> {
+  id: string;
+  template: React.ReactElement | React.ReactElement[];
+  data: T;
+  rowAs?:
+    | React.ExoticComponent<{
+        children?: React.ReactNode;
+      }>
+    | string;
+  // Haven't a clue what this is but it satisfies TypeScript
+  // so fingers crossed
+}
+
+const TableRow = <T,>(props: RowProps<T>) => {
+  const { id, template, data, rowAs } = props;
+  const Row = rowAs || "tr";
+  return (
+    <Row>
+      {React.Children.map(template, (child: React.ReactElement) => {
+        const childProps = child.props as TableColumnProps;
+        const Outer = !!rowAs ? React.Fragment : "td";
+        const Data = !!childProps.wrapper ? childProps.wrapper : React.Fragment;
+        const col = (child.props as TableColumnProps).col as keyof T;
+        if (col) {
+          return (
+            <Outer>
+              <Data data={data[col]}>{data[col]}</Data>
+            </Outer>
+          );
+        }
+        return <Data>{cloneElement(child, { id })}</Data>;
+      })}
+    </Row>
+  );
+};
 
 interface TableProps<T> {
   title?: React.ReactNode;
@@ -8,86 +57,62 @@ interface TableProps<T> {
   children: React.ReactElement | React.ReactElement[];
   hideOnEmpty?: boolean;
   placeholder?: React.ReactNode | React.ReactNode[];
+  tableAs?: React.ReactNode;
+  rowAs?:
+    | React.ExoticComponent<{
+        children?: React.ReactNode;
+      }>
+    | string;
 }
-
-interface TableHeaderProps {
-  col: string;
-}
-
-export const TableHeader: React.FC<TableHeaderProps> = ({ children }) => {
-  return <th>{children}</th>;
-};
-
-interface CellProps<T> {
-  point: T;
-}
-
-const Padding = styled.div`
-  padding-bottom: 16px;
-`;
-
-const TableCell = <T,>(props: CellProps<T>) => {
-  return <td>{props.point}</td>;
-};
-
-interface RowProps<T> {
-  id: string;
-  template: React.ReactElement | React.ReactElement[];
-  data: T;
-}
-
-const TableRow = <T,>(props: RowProps<T>) => {
-  const { id, template, data } = props;
-  return (
-    <tr>
-      {React.Children.map(
-        template,
-        (child: React.ReactElement, index2: number) => {
-          const col = (child.props as TableHeaderProps).col as keyof T;
-          if (col) {
-            return <TableCell point={data[col]}></TableCell>;
-          }
-          return <td>{cloneElement(child, { id })}</td>;
-        }
-      )}
-    </tr>
-  );
-};
 
 const AutoTable = <T extends { id: string }>(props: TableProps<T>) => {
-  const { title, data, children, hideOnEmpty, placeholder } = props;
+  const {
+    title,
+    data,
+    children,
+    hideOnEmpty,
+    placeholder,
+    tableAs,
+    rowAs,
+  } = props;
   const filteredHeaders = useMemo(
     () =>
       React.Children.map(children, (child) => {
-        if (((child as ReactElement).props as TableHeaderProps).col) {
+        if (((child as ReactElement).props as TableColumnProps).col) {
           return child;
         }
         return data.length > 0 ? <th></th> : null;
       }),
     [children, data]
   );
+
+  const Wrapper = !!tableAs ? tableAs : Table;
+  const Body = !!tableAs ? React.Fragment : "tbody";
+
   return data.length === 0 && hideOnEmpty && !placeholder ? null : (
     <>
       {title}
       {data.length === 0 ? (
         <Padding>{placeholder}</Padding>
       ) : (
-        <Table bordered size={"sm"}>
-          <thead>
-            <tr>{filteredHeaders}</tr>
-          </thead>
-
-          <tbody>
+        <Wrapper bordered size={"sm"}>
+          {!tableAs && (
+            <thead>
+              <tr>{filteredHeaders}</tr>
+            </thead>
+          )}
+          <Body>
             {data.map((row: T) => (
               <TableRow
                 key={row.id}
                 id={row.id}
                 data={row}
                 template={children}
+                rowAs={!!tableAs ? rowAs : undefined}
               ></TableRow>
             ))}
-          </tbody>
-        </Table>
+          </Body>
+        </Wrapper>
       )}
     </>
   );

--- a/src/FriendLibraryPage.tsx
+++ b/src/FriendLibraryPage.tsx
@@ -115,12 +115,7 @@ const FriendLibraryPage: React.FC = () => {
         <TableColumn col="title">Title</TableColumn>
         <TableColumn col="author">Author</TableColumn>
         <TableColumn col="summary">Description</TableColumn>
-        <LoanRequestButton
-          id=""
-          books={books}
-          onRequest={handleRequest}
-          onCancel={handleCancel}
-        />
+        <LoanRequestButton onRequest={handleRequest} onCancel={handleCancel} />
       </AutoTable>
       <Modal show={modalOpen} onHide={() => setModalOpen(false)} centered>
         <Modal.Header closeButton>

--- a/src/FriendLibraryPage.tsx
+++ b/src/FriendLibraryPage.tsx
@@ -4,7 +4,7 @@ import { Modal } from "react-bootstrap";
 
 import PageLayout from "./PageLayout";
 import { Book, LoanRequest, Loan, User } from "./ourtypes";
-import AutoTable, { TableHeader } from "./AutoTable";
+import AutoTable, { TableColumn } from "./AutoTable";
 import LoanRequestButton from "./LoanRequestButton";
 import LoanFormik from "./LoanForm";
 
@@ -112,9 +112,9 @@ const FriendLibraryPage: React.FC = () => {
           </span>
         }
       >
-        <TableHeader col="title">Title</TableHeader>
-        <TableHeader col="author">Author</TableHeader>
-        <TableHeader col="summary">Description</TableHeader>
+        <TableColumn col="title">Title</TableColumn>
+        <TableColumn col="author">Author</TableColumn>
+        <TableColumn col="summary">Description</TableColumn>
         <LoanRequestButton
           id=""
           books={books}

--- a/src/FriendRequestButtons.tsx
+++ b/src/FriendRequestButtons.tsx
@@ -4,17 +4,17 @@ import { Button } from "react-bootstrap";
 import { Friend } from "./ourtypes";
 
 interface ButtonGroupProps {
-  data?: Friend;
+  rowItem?: Friend;
   onAccept: (id: string) => {};
   onReject: (id: string) => {};
 }
 
 const FriendRequestButtons: React.FC<ButtonGroupProps> = ({
-  data,
+  rowItem: friend,
   onAccept,
   onReject,
 }) => {
-  if (!data) {
+  if (!friend) {
     throw new Error("Row lacks valid data");
   }
   return (
@@ -24,7 +24,7 @@ const FriendRequestButtons: React.FC<ButtonGroupProps> = ({
         variant="primary"
         size="sm"
         onClick={() => {
-          onAccept(data.id);
+          onAccept(friend.id);
         }}
       >
         Accept
@@ -34,7 +34,7 @@ const FriendRequestButtons: React.FC<ButtonGroupProps> = ({
         variant="outline-danger"
         size="sm"
         onClick={() => {
-          onReject(data.id);
+          onReject(friend.id);
         }}
       >
         Reject

--- a/src/FriendRequestButtons.tsx
+++ b/src/FriendRequestButtons.tsx
@@ -1,25 +1,30 @@
 import React from "react";
 import { Button } from "react-bootstrap";
 
+import { Friend } from "./ourtypes";
+
 interface ButtonGroupProps {
-  id: string;
+  data?: Friend;
   onAccept: (id: string) => {};
   onReject: (id: string) => {};
 }
 
 const FriendRequestButtons: React.FC<ButtonGroupProps> = ({
-  id,
+  data,
   onAccept,
   onReject,
 }) => {
+  if (!data) {
+    throw new Error("Row lacks valid data");
+  }
   return (
-    <div>
+    <>
       <Button
         type="button"
         variant="primary"
         size="sm"
         onClick={() => {
-          onAccept(id);
+          onAccept(data.id);
         }}
       >
         Accept
@@ -29,12 +34,12 @@ const FriendRequestButtons: React.FC<ButtonGroupProps> = ({
         variant="outline-danger"
         size="sm"
         onClick={() => {
-          onReject(id);
+          onReject(data.id);
         }}
       >
         Reject
       </Button>
-    </div>
+    </>
   );
 };
 

--- a/src/FriendsPage.tsx
+++ b/src/FriendsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { Friend } from "./ourtypes";
 import PageLayout from "./PageLayout";
-import AutoTable, { TableHeader } from "./AutoTable";
+import AutoTable, { TableColumn } from "./AutoTable";
 import FriendRequestButtons from "./FriendRequestButtons";
 
 const FriendsPage: React.FC = () => {
@@ -92,7 +92,7 @@ const FriendsPage: React.FC = () => {
           title={<h3>Nearby People</h3>}
           placeholder={"Huh, seems like no one's around..."}
         >
-          <TableHeader col={"name"}>Name</TableHeader>
+          <TableColumn col={"name"}>Name</TableColumn>
           <button>Invite!</button>
         </AutoTable>
       }
@@ -108,7 +108,7 @@ const FriendsPage: React.FC = () => {
             title={<h3>Friend Requests</h3>}
             hideOnEmpty
           >
-            <TableHeader col={"display_name"}>Username</TableHeader>
+            <TableColumn col={"display_name"}>Username</TableColumn>
             <FriendRequestButtons
               id={""}
               onAccept={AcceptFriendship}
@@ -120,7 +120,7 @@ const FriendsPage: React.FC = () => {
             title={<h3>Current Friends</h3>}
             hideOnEmpty
           >
-            <TableHeader col={"display_name"}>Username</TableHeader>
+            <TableColumn col={"display_name"}>Username</TableColumn>
           </AutoTable>
         </>
       )}

--- a/src/FriendsPage.tsx
+++ b/src/FriendsPage.tsx
@@ -110,7 +110,6 @@ const FriendsPage: React.FC = () => {
           >
             <TableColumn col={"display_name"}>Username</TableColumn>
             <FriendRequestButtons
-              id={""}
               onAccept={AcceptFriendship}
               onReject={RejectFriendship}
             />

--- a/src/LibraryPage.tsx
+++ b/src/LibraryPage.tsx
@@ -4,7 +4,7 @@ import { Modal, Button } from "react-bootstrap";
 import PageLayout from "./PageLayout";
 import BookFormik from "./BookForm";
 import { Book } from "./ourtypes";
-import AutoTable, { TableHeader } from "./AutoTable";
+import AutoTable, { TableColumn } from "./AutoTable";
 
 interface ButtonGroupProps {
   id: number;
@@ -25,16 +25,28 @@ const LibraryPage: React.FC = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [isNewBook, setIsNewBook] = useState(true);
   const [selectedBook, setSelectedBook] = useState<Book>(emptyBook);
-  const tableData = {
-    id: "1",
-    user_id: "1",
-    title: "Test book",
-    author: "Some Schmuck",
-    isbn: "978-3-16-148410-0",
-    summary:
-      "this is an example of when I am putting in data with no idea of what to write in.",
-    private: false,
-  };
+  const tableData = [
+    {
+      id: "1",
+      user_id: "1",
+      title: "Test book",
+      author: "Some ",
+      isbn: "978-3-16-148410-0",
+      summary:
+        "this is an example of when I am putting in data with no idea of what to write in.",
+      private: false,
+    },
+    {
+      id: "2",
+      user_id: "1",
+      title: "Test book",
+      author: "Some ",
+      isbn: "978-3-16-148410-0",
+      summary:
+        "this is an example of when I am putting in data with no idea of what to write in.",
+      private: false,
+    },
+  ];
 
   return (
     <PageLayout>
@@ -56,10 +68,10 @@ const LibraryPage: React.FC = () => {
 
       <Button onClick={() => setModalOpen(true)}>New Book</Button>
 
-      <AutoTable data={[tableData]}>
-        <TableHeader col="title">Title</TableHeader>
-        <TableHeader col="author">Author</TableHeader>
-        <TableHeader col="summary">Summary</TableHeader>
+      <AutoTable data={tableData} tableAs="div" rowAs="span">
+        <TableColumn col="title">Title</TableColumn>
+        <TableColumn col="author">Author</TableColumn>
+        <TableColumn col="summary">Summary</TableColumn>
         <button>Edit</button>
       </AutoTable>
     </PageLayout>

--- a/src/LibraryPage.tsx
+++ b/src/LibraryPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Modal, Button } from "react-bootstrap";
 
 import PageLayout from "./PageLayout";
+import LoanStatus from "./LoanStatus";
 import BookFormik from "./BookForm";
 import { Book } from "./ourtypes";
 import AutoTable, { TableColumn } from "./AutoTable";
@@ -25,12 +26,12 @@ const LibraryPage: React.FC = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [isNewBook, setIsNewBook] = useState(true);
   const [selectedBook, setSelectedBook] = useState<Book>(emptyBook);
-  const tableData = [
+  const tableData: Book[] = [
     {
       id: "1",
       user_id: "1",
-      title: "Test book",
-      author: "Some ",
+      title: "Test book 1",
+      author: "A",
       isbn: "978-3-16-148410-0",
       summary:
         "this is an example of when I am putting in data with no idea of what to write in.",
@@ -39,12 +40,25 @@ const LibraryPage: React.FC = () => {
     {
       id: "2",
       user_id: "1",
-      title: "Test book",
-      author: "Some ",
+      title: "Test book 2",
+      author: "B",
       isbn: "978-3-16-148410-0",
       summary:
         "this is an example of when I am putting in data with no idea of what to write in.",
       private: false,
+      loan: {
+        id: "1",
+        book_id: "2",
+        status: "pending",
+        owner_id: "1",
+        owner_contact: "",
+        requester_id: "",
+        requester_contact: "",
+        accept_date: new Date(),
+        request_date: new Date(),
+        loan_start_date: new Date(),
+        loan_end_date: new Date(),
+      },
     },
   ];
 
@@ -68,10 +82,13 @@ const LibraryPage: React.FC = () => {
 
       <Button onClick={() => setModalOpen(true)}>New Book</Button>
 
-      <AutoTable data={tableData} tableAs="div" rowAs="span">
+      <AutoTable data={tableData}>
         <TableColumn col="title">Title</TableColumn>
         <TableColumn col="author">Author</TableColumn>
         <TableColumn col="summary">Summary</TableColumn>
+        <TableColumn col="loan" component={LoanStatus}>
+          Status
+        </TableColumn>
         <button>Edit</button>
       </AutoTable>
     </PageLayout>

--- a/src/LoanRequestButton.tsx
+++ b/src/LoanRequestButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useContext } from "react";
+import React, { useContext } from "react";
 import { Button } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 
@@ -6,24 +6,23 @@ import { AuthContext } from "./AuthContextProvider";
 import { Book, Loan } from "./ourtypes";
 
 interface LRBProps {
-  id: string;
-  books: Book[];
+  data?: Book;
   onRequest: (bookID: string) => void;
   onCancel: (loan: Loan) => void;
 }
 
 const LoanRequestButton: React.FC<LRBProps> = ({
-  id: bookID,
-  books,
+  data: book,
   onRequest: requestLoan,
   onCancel: cancelLoan,
 }) => {
+  if (!book) {
+    throw new Error("Row lacks valid data");
+  }
   const auth = useContext(AuthContext);
   const userID = auth.credential.userId;
-  const existingLoan = useMemo(
-    () => books.find((value: Book) => value.id === bookID)?.loan,
-    [bookID, books]
-  );
+  const existingLoan = book.loan;
+
   auth.logout();
 
   const history = useHistory();
@@ -37,7 +36,7 @@ const LoanRequestButton: React.FC<LRBProps> = ({
     existingLoan.status === "returned" ||
     (existingLoan.status === "pending" && existingLoan.requester_id !== userID)
   ) {
-    return <Button onClick={() => requestLoan(bookID)}>Request Book</Button>;
+    return <Button onClick={() => requestLoan(book.id)}>Request Book</Button>;
   } else if (
     existingLoan.status === "pending" ||
     (existingLoan.status === "accepted" && existingLoan.requester_id === userID)

--- a/src/LoanRequestButton.tsx
+++ b/src/LoanRequestButton.tsx
@@ -24,6 +24,7 @@ const LoanRequestButton: React.FC<LRBProps> = ({
     () => books.find((value: Book) => value.id === bookID)?.loan,
     [bookID, books]
   );
+  auth.logout();
 
   const history = useHistory();
 

--- a/src/LoanRequestButton.tsx
+++ b/src/LoanRequestButton.tsx
@@ -6,13 +6,13 @@ import { AuthContext } from "./AuthContextProvider";
 import { Book, Loan } from "./ourtypes";
 
 interface LRBProps {
-  data?: Book;
+  rowItem?: Book;
   onRequest: (bookID: string) => void;
   onCancel: (loan: Loan) => void;
 }
 
 const LoanRequestButton: React.FC<LRBProps> = ({
-  data: book,
+  rowItem: book,
   onRequest: requestLoan,
   onCancel: cancelLoan,
 }) => {

--- a/src/LoanStatus.tsx
+++ b/src/LoanStatus.tsx
@@ -32,7 +32,7 @@ const LoanStatus: React.FC<LoanStatusProps> = ({ data }) => {
     );
   } else if (data.status === "accepted") {
     return (
-      <NoWrapButton block size="sm" variant="success" onClick={handleClick}>
+      <NoWrapButton block size="sm" variant="warning" onClick={handleClick}>
         Outgoing
       </NoWrapButton>
     );

--- a/src/LoanStatus.tsx
+++ b/src/LoanStatus.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback } from "react";
+import styled from "styled-components";
+import { Button } from "react-bootstrap";
+import { useHistory } from "react-router-dom";
+
+import { Loan } from "./ourtypes";
+
+const NoWrapButton = styled(Button)`
+  white-space: nowrap;
+`;
+
+interface LoanStatusProps {
+  data?: Loan;
+}
+
+const LoanStatus: React.FC<LoanStatusProps> = ({ data }) => {
+  const history = useHistory();
+  const handleClick = useCallback(() => {
+    history.push("/loans");
+  }, [history]);
+  if (!data || data.status === "returned") {
+    return (
+      <NoWrapButton block size="sm" variant="dark" disabled>
+        In Library
+      </NoWrapButton>
+    );
+  } else if (data.status === "pending") {
+    return (
+      <NoWrapButton block size="sm" variant="primary" onClick={handleClick}>
+        Requested
+      </NoWrapButton>
+    );
+  } else if (data.status === "accepted") {
+    return (
+      <NoWrapButton block size="sm" variant="success" onClick={handleClick}>
+        Outgoing
+      </NoWrapButton>
+    );
+  } else {
+    return (
+      <NoWrapButton block size="sm" variant="success" onClick={handleClick}>
+        Loaned Out
+      </NoWrapButton>
+    );
+  }
+};
+
+export default LoanStatus;

--- a/src/LoansPage.tsx
+++ b/src/LoansPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 import { Loan } from "./ourtypes";
 import PageLayout from "./PageLayout";
-import AutoTable, { TableHeader } from "./AutoTable";
+import AutoTable, { TableColumn } from "./AutoTable";
 import { Button } from "react-bootstrap";
 
 const LoansPage: React.FC = () => {
@@ -100,26 +100,26 @@ const LoansPage: React.FC = () => {
               </>
             }
           >
-            <TableHeader col={"requester_id"}>Requester ID</TableHeader>
+            <TableColumn col={"requester_id"}>Requester ID</TableColumn>
             <span>wants</span>
-            <TableHeader col={"book_id"}>Book ID</TableHeader>
+            <TableColumn col={"book_id"}>Book ID</TableColumn>
           </AutoTable>
 
           <AutoTable data={myRequests} title={<h3>My Requests</h3>}>
             <span>You requested</span>
-            <TableHeader col={"book_id"}>Book ID</TableHeader>
+            <TableColumn col={"book_id"}>Book ID</TableColumn>
             <span>from</span>
-            <TableHeader col={"requester_id"}>Requester ID</TableHeader>
+            <TableColumn col={"requester_id"}>Requester ID</TableColumn>
             <Button>Cancel Request?</Button>
           </AutoTable>
 
           <AutoTable data={loanedOut} title={<h3>Loaned Books</h3>} hideOnEmpty>
             <span>You've lent</span>
-            <TableHeader col={"book_id"}>Book ID</TableHeader>
+            <TableColumn col={"book_id"}>Book ID</TableColumn>
             <span>to</span>
-            <TableHeader col={"owner_id"}>Owner ID</TableHeader>
+            <TableColumn col={"owner_id"}>Owner ID</TableColumn>
             <span>due</span>
-            <TableHeader col={"loan_end_date"}>Due Date</TableHeader>
+            <TableColumn col={"loan_end_date"}>Due Date</TableColumn>
           </AutoTable>
 
           <AutoTable
@@ -138,11 +138,11 @@ const LoansPage: React.FC = () => {
             }
           >
             <span>You borrowed</span>
-            <TableHeader col={"book_id"}>Book ID</TableHeader>
+            <TableColumn col={"book_id"}>Book ID</TableColumn>
             <span>from</span>
-            <TableHeader col={"requester_id"}>Requester ID</TableHeader>
+            <TableColumn col={"requester_id"}>Requester ID</TableColumn>
             <span>on</span>
-            <TableHeader col={"loan_start_date"}>Loan Date</TableHeader>
+            <TableColumn col={"loan_start_date"}>Loan Date</TableColumn>
             <Button>Returned It!</Button>
           </AutoTable>
         </>


### PR DESCRIPTION
Update table component to allow custom rendering.
- `TableHeader` now called `TableColumn` (since it's a little clearer) and accepts a `component` prop to render an item
- Objects not wrapped in a column are now injected with a prop `rowItem`
- Can override table rendering using `tableAs` and `rowAs` props in the AutoTable