### PR TITLE
Confirm checks [PAR-43]

### DIFF
--- a/src/ConfirmationContext.tsx
+++ b/src/ConfirmationContext.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export interface Message {
+  title?: string;
+  body: string;
+}
+
+const ConfirmationContext = React.createContext<
+  (message: Message, recall: VoidFunction) => void
+>((message: Message, recall: VoidFunction) => {});
+
+export default ConfirmationContext;

--- a/src/ConfirmationContext.tsx
+++ b/src/ConfirmationContext.tsx
@@ -6,7 +6,7 @@ export interface Message {
 }
 
 const ConfirmationContext = React.createContext<
-  (message: Message, recall: VoidFunction) => void
->((message: Message, recall: VoidFunction) => {});
+  (call: VoidFunction, message: Message) => void
+>((call: VoidFunction, message: Message) => {});
 
 export default ConfirmationContext;

--- a/src/LoanManagementButtons.tsx
+++ b/src/LoanManagementButtons.tsx
@@ -3,6 +3,7 @@ import Button, { ButtonProps } from "react-bootstrap/Button";
 
 import { LoanContext } from "./LoansPage";
 import { Loan, LoanStatus } from "./ourtypes";
+import ConfirmContext from "./ConfirmationContext";
 
 type ButtonVariant = ButtonProps["variant"];
 
@@ -17,6 +18,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
   children,
 }) => {
   const { loans, setLoans } = useContext(LoanContext);
+  const requestConfirmation = useContext(ConfirmContext);
 
   const handleClick = useCallback(() => {
     fetch(`http://paralibrary.digital/api/loans/${thisLoan.id}`, {
@@ -32,7 +34,16 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
   }, [loans, thisLoan, setLoans]);
 
   return (
-    <Button size="sm" onClick={handleClick} variant={variant}>
+    <Button
+      size="sm"
+      onClick={() =>
+        requestConfirmation(
+          { body: "Are you sure you want to delete this?" },
+          handleClick
+        )
+      }
+      variant={variant}
+    >
       {children}
     </Button>
   );

--- a/src/LoanManagementButtons.tsx
+++ b/src/LoanManagementButtons.tsx
@@ -10,12 +10,16 @@ type ButtonVariant = ButtonProps["variant"];
 interface DeleteButtonProps {
   loan: Loan;
   variant?: ButtonVariant;
+  gated?: boolean;
+  message?: string;
 }
 
 export const DeleteButton: React.FC<DeleteButtonProps> = ({
   loan: thisLoan,
   variant,
   children,
+  gated,
+  message,
 }) => {
   const { loans, setLoans } = useContext(LoanContext);
   const requestConfirmation = useContext(ConfirmContext);
@@ -33,15 +37,19 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
       .catch((error) => console.log(error));
   }, [loans, thisLoan, setLoans]);
 
+  const gatedHandle = useCallback(
+    () =>
+      requestConfirmation(handleClick, {
+        title: children as string,
+        body: message || "Are you sure you want to proceed?",
+      }),
+    [requestConfirmation]
+  );
+
   return (
     <Button
       size="sm"
-      onClick={() =>
-        requestConfirmation(
-          { body: "Are you sure you want to delete this?" },
-          handleClick
-        )
-      }
+      onClick={gated ? gatedHandle : handleClick}
       variant={variant}
     >
       {children}
@@ -53,6 +61,8 @@ interface UpdateButtonProps {
   loan: Loan;
   variant?: ButtonVariant;
   status: LoanStatus;
+  gated?: boolean;
+  message?: string;
 }
 
 export const UpdateButton: React.FC<UpdateButtonProps> = ({
@@ -60,8 +70,11 @@ export const UpdateButton: React.FC<UpdateButtonProps> = ({
   status: thisStatus,
   variant,
   children,
+  gated,
+  message,
 }) => {
   const { loans, setLoans } = useContext(LoanContext);
+  const requestConfirmation = useContext(ConfirmContext);
 
   const handleClick = useCallback(() => {
     const newLoan: Loan = { ...thisLoan, status: thisStatus };
@@ -82,8 +95,21 @@ export const UpdateButton: React.FC<UpdateButtonProps> = ({
       })
       .catch((error) => console.log(error));
   }, [loans, thisLoan, setLoans, thisStatus]);
+
+  const gatedHandle = useCallback(
+    () =>
+      requestConfirmation(handleClick, {
+        title: children as string,
+        body: message || "Are you sure you want to proceed?",
+      }),
+    [requestConfirmation]
+  );
   return (
-    <Button size="sm" onClick={handleClick} variant={variant}>
+    <Button
+      size="sm"
+      onClick={gated ? gatedHandle : handleClick}
+      variant={variant}
+    >
       {children}
     </Button>
   );

--- a/src/LoanManagers.tsx
+++ b/src/LoanManagers.tsx
@@ -37,7 +37,12 @@ export const OwnerLoanManager: React.FC<LMProps> = ({ rowitem: loan }) => {
         </UpdateButton>
       )}
       {loan.status === "pending" && (
-        <DeleteButton variant="outline-danger" loan={loan}>
+        <DeleteButton
+          variant="outline-danger"
+          loan={loan}
+          gated
+          message="Are you sure you want to decline this request?"
+        >
           Decline
         </DeleteButton>
       )}
@@ -45,7 +50,12 @@ export const OwnerLoanManager: React.FC<LMProps> = ({ rowitem: loan }) => {
         <ContactButton loan={loan} userType="requester" />
       )}
       {loan.status === "loaned" && (
-        <UpdateButton loan={loan} status="loaned">
+        <UpdateButton
+          loan={loan}
+          status="returned"
+          gated
+          message="Do you have this book in your possession?"
+        >
           Book returned
         </UpdateButton>
       )}
@@ -69,7 +79,12 @@ export const RequesterLoanManager: React.FC<LMProps> = ({ rowitem: loan }) => {
         </UpdateButton>
       )}
       {(loan.status === "pending" || loan.status === "accepted") && (
-        <DeleteButton variant="outline-danger" loan={loan}>
+        <DeleteButton
+          variant="outline-danger"
+          loan={loan}
+          gated
+          message="Are you sure you want to cancel this request?"
+        >
           Cancel
         </DeleteButton>
         // Maybe eventually this will become a transition to the declined state

--- a/src/PageLayout.tsx
+++ b/src/PageLayout.tsx
@@ -58,10 +58,10 @@ const PageLayout: React.FC<PageLayoutProps> = ({
   });
   const action = useRef<VoidFunction>(() => {});
 
-  const requestConfirmation = (message: Message, recall: VoidFunction) => {
+  const requestConfirmation = (call: VoidFunction, message: Message) => {
     setConfirmMessage(message);
     setConfirmModalOpen(true);
-    action.current = recall;
+    action.current = call;
   };
 
   const handleConfirm = useCallback(() => {
@@ -91,9 +91,9 @@ const PageLayout: React.FC<PageLayoutProps> = ({
               <Main>{children}</Main>
               {sidebar && <Sidebar>{sidebar}</Sidebar>}
 
-              <Modal centered show={confirmModalOpen} onHide={handleCancel}>
+              <Modal show={confirmModalOpen} onHide={handleCancel}>
                 <Modal.Header closeButton>
-                  <Modal.Title>{confirmMessage.title}</Modal.Title>
+                  <Modal.Title>{confirmMessage.title || "Confirm"}</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>{confirmMessage.body}</Modal.Body>
                 <Modal.Footer>

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -46,15 +46,15 @@ export function toBook(obj: any): Book {
     throw new Error("Missing property 'title' in book");
   }
 
-  if (!obj.author) {
-    throw new Error("Missing property 'author' in book");
-  }
+  // if (!obj.author) {
+  //   throw new Error("Missing property 'author' in book");
+  // }
   // if (!obj.isbn) {
   //   throw new Error("Missing property 'isbn' in book");
   // }
-  if (!obj.summary) {
-    throw new Error("Missing property 'summary' in book");
-  }
+  // if (!obj.summary) {
+  //   throw new Error("Missing property 'summary' in book");
+  // }
   if (!(obj.visibility as Visibility)) {
     throw new Error("Missing or invalid property 'visibility' in book");
   }


### PR DESCRIPTION
Created a confirmation context that wraps the page layout and added a modal. Now any event handler can be wrapped in a `requestConfirm` function that will forward the call to a button on the modal.