### PR TITLE
Permissive mappers [PAR-81]

### DIFF
--- a/src/FriendshipStatusButton.tsx
+++ b/src/FriendshipStatusButton.tsx
@@ -29,7 +29,7 @@ const FriendshipRequestButton: React.FC<FRBProps> = ({ friend, onClick }) => {
         onClick({ ...friend, status: "requested" });
       })
       .catch((error) => console.log(error));
-  }, [friend]);
+  }, [friend, onClick]);
 
   function onAcceptClicked() {
     onClick({ ...friend, status: "friends" });

--- a/src/LoanManagementButtons.tsx
+++ b/src/LoanManagementButtons.tsx
@@ -43,7 +43,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
         title: children as string,
         body: message || "Are you sure you want to proceed?",
       }),
-    [requestConfirmation]
+    [requestConfirmation, children, handleClick, message]
   );
 
   return (
@@ -102,7 +102,7 @@ export const UpdateButton: React.FC<UpdateButtonProps> = ({
         title: children as string,
         body: message || "Are you sure you want to proceed?",
       }),
-    [requestConfirmation]
+    [requestConfirmation, children, handleClick, message]
   );
   return (
     <Button

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -8,6 +8,8 @@ import {
   LoanStatus,
 } from "./ourtypes";
 
+import { isNullOrUndefined } from "util";
+
 export function toLibrary(obj: any): Library {
   if (!obj.user) {
     throw new Error("Missing property 'user' in library");
@@ -48,10 +50,10 @@ export function toBook(obj: any): Book {
   if (!obj.author) {
     throw new Error("Missing property 'author' in book");
   }
-  if (obj.isbn === undefined) {
+  if (isNullOrUndefined(obj.isbn)) {
     throw new Error("Missing property 'isbn' in book");
   }
-  if (obj.summary === undefined) {
+  if (isNullOrUndefined(obj.summary)) {
     throw new Error("Missing property 'summary' in book");
   }
   if (!(obj.visibility as Visibility)) {

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -44,10 +44,10 @@ export function toBook(obj: any): Book {
   if (!obj.user_id) {
     throw new Error("Missing property 'user_id' in book");
   }
-  if (!obj.title) {
+  if (isNullOrUndefined(obj.title)) {
     throw new Error("Missing property 'title' in book");
   }
-  if (!obj.author) {
+  if (isNullOrUndefined(obj.author)) {
     throw new Error("Missing property 'author' in book");
   }
   if (isNullOrUndefined(obj.isbn)) {

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -36,22 +36,22 @@ export function toUser(obj: any): User {
 }
 
 export function toBook(obj: any): Book {
-  if (!(obj.id as string)) {
+  if (!obj.id) {
     throw new Error("Missing property 'id' in book");
   }
-  if (!(obj.user_id as string)) {
+  if (!obj.user_id) {
     throw new Error("Missing property 'user_id' in book");
   }
-  if (!(obj.title as string)) {
+  if (!obj.title) {
     throw new Error("Missing property 'title' in book");
   }
-  if (!(obj.author as string)) {
+  if (!obj.author) {
     throw new Error("Missing property 'author' in book");
   }
-  if (!(obj.isbn as string)) {
+  if (obj.isbn === undefined) {
     throw new Error("Missing property 'isbn' in book");
   }
-  if (!(obj.summary as string)) {
+  if (obj.summary === undefined) {
     throw new Error("Missing property 'summary' in book");
   }
   if (!(obj.visibility as Visibility)) {

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -36,25 +36,24 @@ export function toUser(obj: any): User {
 }
 
 export function toBook(obj: any): Book {
-  if (!obj.id) {
+  if (!(obj.id as string)) {
     throw new Error("Missing property 'id' in book");
   }
-  if (!obj.user_id) {
+  if (!(obj.user_id as string)) {
     throw new Error("Missing property 'user_id' in book");
   }
-  if (!obj.title) {
+  if (!(obj.title as string)) {
     throw new Error("Missing property 'title' in book");
   }
-
-  // if (!obj.author) {
-  //   throw new Error("Missing property 'author' in book");
-  // }
-  // if (!obj.isbn) {
-  //   throw new Error("Missing property 'isbn' in book");
-  // }
-  // if (!obj.summary) {
-  //   throw new Error("Missing property 'summary' in book");
-  // }
+  if (!(obj.author as string)) {
+    throw new Error("Missing property 'author' in book");
+  }
+  if (!(obj.isbn as string)) {
+    throw new Error("Missing property 'isbn' in book");
+  }
+  if (!(obj.summary as string)) {
+    throw new Error("Missing property 'summary' in book");
+  }
   if (!(obj.visibility as Visibility)) {
     throw new Error("Missing or invalid property 'visibility' in book");
   }
@@ -90,18 +89,7 @@ export function toLoan(obj: any): Loan {
   if (!book && !obj.book_id) {
     throw new Error("Missing property 'book' and 'book_id' in loan");
   }
-  // if (!obj.request_date) {
-  //   throw new Error("Missing property 'request_date' in loan");
-  // }
-  // if (!obj.accept_date) {
-  //   throw new Error("Missing property 'accept_date' in loan");
-  // }
-  // if (!obj.loan_start_date) {
-  //   throw new Error("Missing property 'loan_start_date' in loan");
-  // }
-  // if (!obj.loan_end_date) {
-  //   throw new Error("Missing property 'loan_end_date' in loan");
-  // }
+
   if (!(obj.status as LoanStatus)) {
     throw new Error("Missing property 'status' in loan");
   }
@@ -112,10 +100,10 @@ export function toLoan(obj: any): Loan {
     requester,
     owner,
     requester_contact: obj.requester_contact,
-    request_date: new Date(obj.request_date),
-    accept_date: new Date(obj.accept_date),
-    loan_start_date: new Date(obj.loan_start_date),
-    loan_end_date: new Date(obj.loan_end_date),
+    request_date: obj.request_date && new Date(obj.request_date),
+    accept_date: obj.accept_date && new Date(obj.accept_date),
+    loan_start_date: obj.loan_start_date && new Date(obj.loan_start_date),
+    loan_end_date: obj.loan_end_date && new Date(obj.loan_end_date),
     status: obj.status,
   };
 }

--- a/src/ourtypes.ts
+++ b/src/ourtypes.ts
@@ -5,10 +5,10 @@ export interface Loan extends LoanRequest {
   requester: User;
   requester_contact: string;
   book?: Book;
-  request_date: Date;
-  accept_date: Date;
-  loan_start_date: Date;
-  loan_end_date: Date;
+  request_date?: Date;
+  accept_date?: Date;
+  loan_start_date?: Date;
+  loan_end_date?: Date;
   status: LoanStatus;
 }
 


### PR DESCRIPTION
Now mappers only check for `undefined` or `null` on optional string values. @vastImmortalSuns this reveals that the book objects returned by the `/libraries` route have a null ISBN field and that book objects attached to loans coming through the `/loans/requester|owner` route have only a title field: author, isbn, and summary are all missing.