### PR TITLE
Loan and tag bug squash [PAR-107] [PAR-112]

### DIFF
--- a/src/BookForm.tsx
+++ b/src/BookForm.tsx
@@ -29,7 +29,8 @@ const BookForm: React.FC<FormikProps<Book> & ExtraProps> = ({
   );
 
   const mapToCategories = useCallback(
-    (options: Option[]): string[] => options.map((opt) => opt.value),
+    (options: Option[] | null): string[] =>
+      !options ? [] : options.map((opt) => opt.value),
     []
   );
 

--- a/src/LoansPage.tsx
+++ b/src/LoansPage.tsx
@@ -117,6 +117,7 @@ const LoansPage: React.FC = () => {
     // May need to revise this once we loan management flow
     [loanedByMe]
   );
+  console.log(loanedOut);
 
   return (
     <PageLayout
@@ -158,7 +159,7 @@ const LoansPage: React.FC = () => {
         <List
           items={loanedOut}
           title={<h3>My Loaning</h3>}
-          userRole="requester"
+          userRole="owner"
           component={LoanDisplay}
         />
       </LoanContext.Provider>


### PR DESCRIPTION
You can now delete the last tag on a book without silently crashing the page and books you've loaned out now show the proper message and UI.