### PR TITLE
Fix issues with image in header by shrinking things

### DIFF
--- a/src/AboutPage.tsx
+++ b/src/AboutPage.tsx
@@ -34,9 +34,9 @@ const AboutPage: React.FC = () => {
       <p>
         ParaLibrary took inspiration from programs such as Little Free Library
         that make books available to anyone. However, we wanted to give the user
-        more oversite since you may want to share a book you love with someone
+        more oversight since you may want to share a book you love with someone
         else but still like to know where it is. It's also a great tool if you
-        just want to keep track of all the books in your house!
+        just want to keep track of all the books you own!
       </p>
       <h3>Core Features</h3>
       <ul>

--- a/src/LibraryHeader.tsx
+++ b/src/LibraryHeader.tsx
@@ -5,6 +5,7 @@ import Image from "react-bootstrap/Image";
 const HeaderContainer = styled.div`
   display: flex;
   max-width: 100%;
+  margin-bottom: 16px;
 `;
 
 const UserImage = styled(Image)`

--- a/src/LibraryHeader.tsx
+++ b/src/LibraryHeader.tsx
@@ -3,26 +3,17 @@ import styled from "styled-components";
 import Image from "react-bootstrap/Image";
 
 const HeaderContainer = styled.div`
-  display: block;
-  margin-bottom: 16px;
+  display: flex;
   max-width: 100%;
-  @media screen and (min-width: ${({ theme }) => theme.smallViewport}) {
-    display: grid;
-    grid-template-columns: min-content auto;
-    grid-column-gap: 16px;
-    margin-bottom: 0px;
-  }
 `;
 
 const UserImage = styled(Image)`
-  display: none;
+  display: inline;
+  float: left;
   object-fit: contain;
-  height: 100%;
-  max-height: 96px;
-  max-width: 96px;
-  @media screen and (min-width: ${({ theme }) => theme.smallViewport}) {
-    display: block;
-  }
+  height: 48px;
+  width: auto;
+  margin-right: 16px;
 `;
 
 interface LHProps {
@@ -34,7 +25,7 @@ const LibraryHeader: React.FC<LHProps> = ({ name, picture }) => {
   return (
     <HeaderContainer>
       <UserImage src={picture || "./images/defaultAvatar.jpg"} rounded />
-      <h1>{!name ? "My" : `${name}'s`} Library</h1>
+      <h2>{!name ? "My" : `${name}'s`} Library</h2>
     </HeaderContainer>
   );
 };

--- a/src/PageLayout.tsx
+++ b/src/PageLayout.tsx
@@ -22,7 +22,7 @@ const Layout = styled.div`
   flex-flow: column nowrap;
   padding: 16px;
 
-  @media screen and (min-width: ${({ theme }) => theme.smallViewport}) {
+  @media screen and (min-width: ${({ theme }) => theme.largeViewport}) {
     flex: 1 0;
     display: grid;
     grid-template-columns: auto 30%;
@@ -38,7 +38,7 @@ const Layout = styled.div`
 
 const Main = styled.div`
   position: sticky;
-  @media screen and (min-width: ${({ theme }) => theme.smallViewport}) {
+  @media screen and (min-width: ${({ theme }) => theme.largeViewport}) {
     grid-area: main;
     position: static;
     top: auto;


### PR DESCRIPTION
This is to fix a bug with text overlapping a user icon when viewing a friend's page. Not sure what why the bug was occurring, since it seemed to only appear when names are pretty long. If anyone is a real CSS wizard, I don't think this is the best solution but it works better now.